### PR TITLE
Remove 'final' modifiers from several filter classes

### DIFF
--- a/src/main/java/io/buji/oauth/filter/OAuthFormAuthenticationFilter.java
+++ b/src/main/java/io/buji/oauth/filter/OAuthFormAuthenticationFilter.java
@@ -29,7 +29,7 @@ import org.scribe.up.provider.OAuthProvider;
  * @author Jerome Leleu
  * @since 1.0.0
  */
-public final class OAuthFormAuthenticationFilter extends FormAuthenticationFilter {
+public class OAuthFormAuthenticationFilter extends FormAuthenticationFilter {
     
     private OAuthProvider provider;
     

--- a/src/main/java/io/buji/oauth/filter/OAuthPermissionsAuthorizationFilter.java
+++ b/src/main/java/io/buji/oauth/filter/OAuthPermissionsAuthorizationFilter.java
@@ -29,7 +29,7 @@ import org.scribe.up.provider.OAuthProvider;
  * @author Jerome Leleu
  * @since 1.0.0
  */
-public final class OAuthPermissionsAuthorizationFilter extends PermissionsAuthorizationFilter {
+public class OAuthPermissionsAuthorizationFilter extends PermissionsAuthorizationFilter {
     
     private OAuthProvider provider;
     

--- a/src/main/java/io/buji/oauth/filter/OAuthUserFilter.java
+++ b/src/main/java/io/buji/oauth/filter/OAuthUserFilter.java
@@ -29,7 +29,7 @@ import org.scribe.up.provider.OAuthProvider;
  * @author Jerome Leleu
  * @since 1.0.0
  */
-public final class OAuthUserFilter extends UserFilter {
+public class OAuthUserFilter extends UserFilter {
     
     private OAuthProvider provider;
     


### PR DESCRIPTION
Remaining 'final' modifiers should be removed from filter classes to make code reuse easier, e.g., when using DI with annotations.
