### PR TITLE
Added casPassThrough. By default false, in case this set to true it will

### DIFF
--- a/src/main/java/io/buji/pac4j/ClientFilter.java
+++ b/src/main/java/io/buji/pac4j/ClientFilter.java
@@ -56,7 +56,7 @@ public class ClientFilter extends AuthenticatingFilter {
     private Clients clients;
     
     // This flag controls the behaviour of the filter after successful redirection
-    private boolean redirectAfterSuccessfulAuthentication = false;
+    private boolean redirectAfterSuccessfulAuthentication = true;
     
     /**
      * The token created for this authentication is a ClientToken containing the credentials received after authentication at the provider.


### PR DESCRIPTION
Added casPassThrough. By default false, in case this set to true it will pass the request through the filter chain instead of issuing a redirect.
This is make cas proxy authentication work when cas proxying is
initiated from a java client application.

As the ClientFilter is more generic (i.e. used for authentication
mechanisms than Cas) probably a tighter check is required. One approach
may be to check for presense of CasProxyProfile in the
principalCollction but would require a dependency on pac4j-cas which is
not there at present.
