### PR TITLE
changed setClient Parameter to ? extends

### DIFF
--- a/servlet/src/main/java/io/buji/pac4j/filter/ClientRolesAuthorizationFilter.java
+++ b/servlet/src/main/java/io/buji/pac4j/filter/ClientRolesAuthorizationFilter.java
@@ -40,7 +40,7 @@ import org.pac4j.core.profile.CommonProfile;
  */
 public class ClientRolesAuthorizationFilter extends RolesAuthorizationFilter {
 
-    protected IndirectClient<Credentials, CommonProfile> client;
+    protected IndirectClient<? extends Credentials, ? extends CommonProfile> client;
 
     @Override
     protected boolean isLoginRequest(final ServletRequest request, final ServletResponse response) {
@@ -56,7 +56,7 @@ public class ClientRolesAuthorizationFilter extends RolesAuthorizationFilter {
         }
     }
 
-    public void setClient(final IndirectClient<Credentials, CommonProfile> client) {
+    public void setClient(final IndirectClient<? extends Credentials, ? extends CommonProfile> client) {
         this.client = client;
     }
 }

--- a/servlet/src/test/java/io/buji/pac4j/filter/ClientRolesAuthorizationFilterTest.java
+++ b/servlet/src/test/java/io/buji/pac4j/filter/ClientRolesAuthorizationFilterTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.CommonProfile;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -83,6 +85,21 @@ public class ClientRolesAuthorizationFilterTest {
 		// when
 		clientRolesAuthorizationFilter.setClient(indirectClientMock);
 		
+		// then
+		assertEquals("Client must be set to " + indirectClientMock, indirectClientMock, getInternalState(clientRolesAuthorizationFilter, "client"));
+	}
+
+	/**
+	 * Test for setClient with subclasses of {@link IndirectClient}, e.g. CasClient.
+	 */
+	@Test
+	public final void testSetClientWithExtends() {
+		// given
+		IndirectClient<? extends Credentials, ? extends CommonProfile> indirectClientMock = mock(IndirectClient.class);
+
+		// when
+		clientRolesAuthorizationFilter.setClient(indirectClientMock);
+
 		// then
 		assertEquals("Client must be set to " + indirectClientMock, indirectClientMock, getInternalState(clientRolesAuthorizationFilter, "client"));
 	}


### PR DESCRIPTION
pure java config is currently not possible?

In the current version the following snippet does not compile.
```
ClientRolesAuthorizationFilter casRoles = new ClientRolesAuthorizationFilter();
casRoles.setClient(new CasClient());
```
The error is:
`java: incompatible types: org.pac4j.cas.client.CasClient cannot be converted to org.pac4j.core.client.IndirectClient<org.pac4j.core.credentials.Credentials,org.pac4j.core.profile.CommonProfile>`

With this patch the snippet compiles.