### PR TITLE
Specify the attribute used for Pac4jPrincipal.getName()  on master

### DIFF
--- a/src/main/java/io/buji/pac4j/realm/Pac4jRealm.java
+++ b/src/main/java/io/buji/pac4j/realm/Pac4jRealm.java
@@ -40,11 +40,39 @@ import java.util.*;
  * @since 2.0.0
  */
 public class Pac4jRealm extends AuthorizingRealm {
+    
+    private String principalNameAttribute;
 
     public Pac4jRealm() {
         setAuthenticationTokenClass(Pac4jToken.class);
     }
 
+    /**
+     * Returns the name of the attribute from CommonProfile that will be used as
+     * the value for the principal name.
+     * 
+     * @return an attribute name or null
+     */
+    public String getPrincipalNameAttribute() {
+        return principalNameAttribute;
+    }
+
+    /**
+     * Sets the name of the attribute from the CommonProfile that should be returned
+     * as the principal name. Common attribute names include "email", "username" or "display_name"
+     * but valid values are ultimately determined by the Pac4j client and the profile 
+     * that it returns. A null or blank string provided for the attribute name will
+     * cause the principal to return CommonProfile.getId() as the name.
+     * 
+     * @param principalNameAttribute The attribute name to return. Null or blank will
+     *          result in CommonProfile.getId() being used for the principal name.
+     * @see Pac4jPrincipal#getName()
+     * @see CommonProfile
+     */
+    public void setPrincipalNameAttribute(String principalNameAttribute) {
+        this.principalNameAttribute = principalNameAttribute;
+    }
+    
     @Override
     protected AuthenticationInfo doGetAuthenticationInfo(final AuthenticationToken authenticationToken)
             throws AuthenticationException {
@@ -52,7 +80,7 @@ public class Pac4jRealm extends AuthorizingRealm {
         final Pac4jToken token = (Pac4jToken) authenticationToken;
         final LinkedHashMap<String, CommonProfile> profiles = token.getProfiles();
 
-        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles);
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, principalNameAttribute);
         final PrincipalCollection principalCollection = new SimplePrincipalCollection(principal, getName());
         return new SimpleAuthenticationInfo(principalCollection, profiles.hashCode());
     }

--- a/src/main/java/io/buji/pac4j/subject/Pac4jPrincipal.java
+++ b/src/main/java/io/buji/pac4j/subject/Pac4jPrincipal.java
@@ -28,17 +28,42 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
- * The principal to store the pac4j profiles.
- *
+ * A principal created by Pac4JRealm that wraps a CommonProfile.
+ * 
  * @author Jerome Leleu
  * @since 2.0.0
  */
 public class Pac4jPrincipal implements Principal, Serializable {
 
+    private final String principalNameAttribute;
     private final LinkedHashMap<String, CommonProfile> profiles;
 
+    /**
+     * Construct a Pac4jPrincipal.  The principal name returned will be 
+     * CommonProfile.getId().
+     * 
+     * @param profiles A map containing all of the CommonProfiles created by Pac4j
+     *          authorization.
+     */
     public Pac4jPrincipal(final LinkedHashMap<String, CommonProfile> profiles) {
         this.profiles = profiles;
+        this.principalNameAttribute = null;
+    }
+    
+    /**
+     * Construct a Pac4jPrincipal and specify which attribute in the CommonProfile
+     * should be used for the principal name.
+     * 
+     * @param profiles A map containing all of the CommonProfiles created by Pac4j
+     *          authorization.
+     * @param principalNameAttribute The attribute name in the CommonProfile that 
+     *          holds the principal name. A null or blank value means
+     *          that CommonProfile.getId() should be used as the principal name.
+     */
+    public Pac4jPrincipal(final LinkedHashMap<String, CommonProfile> profiles, String principalNameAttribute) {
+        this.profiles = profiles;
+        this.principalNameAttribute = CommonHelper.isBlank(principalNameAttribute) ?
+                                        null : principalNameAttribute.trim();
     }
 
     /**
@@ -73,11 +98,21 @@ public class Pac4jPrincipal implements Principal, Serializable {
         return profiles != null ? profiles.hashCode() : 0;
     }
 
+    /**
+     * Returns a name for the principal based upon one of the attributes
+     * of the main CommonProfile.  The attribute name used to query the CommonProfile 
+     * is specified in the constructor. 
+     * 
+     * @return a name for the Principal or null if the attribute is not populated.
+     */
     @Override
     public String getName() {
         CommonProfile profile = this.getProfile();
-        return profile.getId();
-
+        if(null == principalNameAttribute) {
+            return profile.getId();
+        }
+        Object attrValue = profile.getAttribute(principalNameAttribute);
+        return (null == attrValue) ? null : String.valueOf(attrValue);
     }
 
     @Override

--- a/src/test/java/io/buji/pac4j/subject/Pac4jPrincipalTests.java
+++ b/src/test/java/io/buji/pac4j/subject/Pac4jPrincipalTests.java
@@ -7,6 +7,7 @@ import org.pac4j.core.profile.CommonProfile;
 import java.util.LinkedHashMap;
 
 import static org.junit.Assert.*;
+import org.pac4j.core.context.Pac4jConstants;
 
 /**
  * Tests {@link Pac4jPrincipal}.
@@ -15,6 +16,10 @@ import static org.junit.Assert.*;
  * @since 2.0.1
  */
 public final class Pac4jPrincipalTests {
+    
+    private static final String PROFILE_ID = "123";
+    private static final String TEST_USERNAME = "superman";
+    private static final String TEST_EMAIL = "clark.kent@dailyplanet.org";
 
     @Test
     public void testSerialize() {
@@ -25,5 +30,81 @@ public final class Pac4jPrincipalTests {
         final byte[] serialized = serializer.serialize(principal);
         final Pac4jPrincipal principal2 = (Pac4jPrincipal) serializer.deserialize(serialized);
         assertEquals(principal2, principal);
+    }
+    
+    @Test 
+    public void testNoAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles);
+        assertEquals(PROFILE_ID, principal.getName());
+    }
+    
+    @Test 
+    public void testBlankAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, " ");
+        assertEquals(PROFILE_ID, principal.getName());
+    }
+    
+    @Test 
+    public void testNullAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, null);
+        assertEquals(PROFILE_ID, principal.getName());
+    }
+    
+    @Test 
+    public void testLeftPaddedAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, "  " + Pac4jConstants.USERNAME);
+        assertEquals(TEST_USERNAME, principal.getName());
+    }
+    
+    @Test 
+    public void testRightPaddedAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, Pac4jConstants.USERNAME + " ");
+        assertEquals(TEST_USERNAME, principal.getName());
+    }
+    
+    @Test 
+    public void testUsernameAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, Pac4jConstants.USERNAME);
+        assertEquals(TEST_USERNAME, principal.getName());
+    }
+    
+    @Test 
+    public void testEmailAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, "email");
+        assertEquals(TEST_EMAIL, principal.getName());
+    }
+    
+    @Test 
+    public void testNonExistantAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, "display_name");
+        assertNull(principal.getName());
+    }
+    
+    @Test 
+    public void testIntegerAttribute() {
+        final LinkedHashMap<String, CommonProfile> profiles = createProfiles();
+        final Pac4jPrincipal principal = new Pac4jPrincipal(profiles, "age");
+        assertEquals(principal.getName(), "21");
+    }
+    
+    private static LinkedHashMap<String, CommonProfile> createProfiles() {
+        CommonProfile profile = new CommonProfile();
+        profile.setId(PROFILE_ID);
+        profile.addAttribute(Pac4jConstants.USERNAME, TEST_USERNAME);
+        profile.addAttribute("family_name", "Kent");
+        profile.addAttribute("first_name", "Clark");
+        profile.addAttribute("email", TEST_EMAIL);
+        profile.addAttribute("age", 21);
+        LinkedHashMap<String, CommonProfile> profiles = new LinkedHashMap<>();
+        profiles.put("test", profile);
+        return profiles;
     }
 }


### PR DESCRIPTION
Allows a user to configure the attribute name from the CommonProfile that should be returned by Pac4jPrincipal.getName().

See #61 