### PR TITLE
Add specialized callbacklogic and securitylogic in buji

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ If you have any question, please use the following mailing lists:
 
 ## Development
 
-The version 3.1.1-SNAPSHOT is under development.
+The version 3.2.0-SNAPSHOT is under development.
 
 Maven artifacts are built via Travis: [![Build Status](https://travis-ci.org/bujiio/buji-pac4j.png?branch=master)](https://travis-ci.org/bujiio/buji-pac4j) and available in the [Sonatype snapshots repository](https://oss.sonatype.org/content/repositories/snapshots/org/pac4j). This repository must be added in the Maven *pom.xml* file for example:
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>buji-pac4j</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>pac4j implementation for Shiro</name>
   <description>Security library for Shiro based on pac4j</description>

--- a/src/main/java/io/buji/pac4j/engine/ShiroCallbackLogic.java
+++ b/src/main/java/io/buji/pac4j/engine/ShiroCallbackLogic.java
@@ -1,0 +1,15 @@
+package io.buji.pac4j.engine;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.engine.DefaultCallbackLogic;
+
+import io.buji.pac4j.profile.ShiroProfileManager;
+
+public class ShiroCallbackLogic<R, C extends WebContext> extends DefaultCallbackLogic<R, C> {
+
+    public ShiroCallbackLogic() {
+        super();
+        this.setProfileManagerFactory(ShiroProfileManager::new);
+    }
+
+}

--- a/src/main/java/io/buji/pac4j/engine/ShiroCallbackLogic.java
+++ b/src/main/java/io/buji/pac4j/engine/ShiroCallbackLogic.java
@@ -5,6 +5,14 @@ import org.pac4j.core.engine.DefaultCallbackLogic;
 
 import io.buji.pac4j.profile.ShiroProfileManager;
 
+/**
+ * Specialized CallbackLogic aimed for buji : makes a clean use of the ShiroProfileManager.
+ *
+ * @see DefaultCallbackLogic
+ *
+ * @author Andre Doherty
+ * @Since 3.2.0
+ */
 public class ShiroCallbackLogic<R, C extends WebContext> extends DefaultCallbackLogic<R, C> {
 
     public ShiroCallbackLogic() {

--- a/src/main/java/io/buji/pac4j/engine/ShiroSecurityLogic.java
+++ b/src/main/java/io/buji/pac4j/engine/ShiroSecurityLogic.java
@@ -1,0 +1,15 @@
+package io.buji.pac4j.engine;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.engine.DefaultSecurityLogic;
+
+import io.buji.pac4j.profile.ShiroProfileManager;
+
+public class ShiroSecurityLogic<R, C extends WebContext> extends DefaultSecurityLogic<R, C> {
+
+    public ShiroSecurityLogic() {
+        super();
+        this.setProfileManagerFactory(ShiroProfileManager::new);
+    }
+
+}

--- a/src/main/java/io/buji/pac4j/engine/ShiroSecurityLogic.java
+++ b/src/main/java/io/buji/pac4j/engine/ShiroSecurityLogic.java
@@ -5,6 +5,14 @@ import org.pac4j.core.engine.DefaultSecurityLogic;
 
 import io.buji.pac4j.profile.ShiroProfileManager;
 
+/**
+ * Specialized SecurityLogic aimed for buji : makes a clean use of the ShiroProfileManager.
+ *
+ * @see DefaultSecurityLogic
+ *
+ * @author Andre Doherty
+ * @Since 3.2.0
+ */
 public class ShiroSecurityLogic<R, C extends WebContext> extends DefaultSecurityLogic<R, C> {
 
     public ShiroSecurityLogic() {

--- a/src/main/java/io/buji/pac4j/filter/CallbackFilter.java
+++ b/src/main/java/io/buji/pac4j/filter/CallbackFilter.java
@@ -18,22 +18,28 @@
  */
 package io.buji.pac4j.filter;
 
-import io.buji.pac4j.context.ShiroSessionStore;
-import io.buji.pac4j.profile.ShiroProfileManager;
+import static org.pac4j.core.util.CommonHelper.assertNotNull;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.engine.CallbackLogic;
-import org.pac4j.core.engine.DefaultCallbackLogic;
 import org.pac4j.core.http.HttpActionAdapter;
 import org.pac4j.core.http.J2ENopHttpActionAdapter;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-import static org.pac4j.core.util.CommonHelper.assertNotNull;
+import io.buji.pac4j.context.ShiroSessionStore;
+import io.buji.pac4j.engine.ShiroCallbackLogic;
 
 /**
  * <p>This filter finishes the login process for an indirect client, based on the {@link #callbackLogic}.</p>
@@ -57,8 +63,7 @@ public class CallbackFilter implements Filter {
     private HttpActionAdapter<Object, J2EContext> httpActionAdapter;
 
     public CallbackFilter() {
-        callbackLogic = new DefaultCallbackLogic<>();
-        ((DefaultCallbackLogic<Object, J2EContext>) callbackLogic).setProfileManagerFactory(ShiroProfileManager::new);
+        callbackLogic = new ShiroCallbackLogic<>();
     }
 
     @Override

--- a/src/main/java/io/buji/pac4j/filter/SecurityFilter.java
+++ b/src/main/java/io/buji/pac4j/filter/SecurityFilter.java
@@ -18,21 +18,27 @@
  */
 package io.buji.pac4j.filter;
 
-import io.buji.pac4j.context.ShiroSessionStore;
-import io.buji.pac4j.profile.ShiroProfileManager;
+import static org.pac4j.core.util.CommonHelper.assertNotNull;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.session.SessionStore;
-import org.pac4j.core.engine.DefaultSecurityLogic;
 import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.http.J2ENopHttpActionAdapter;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-import static org.pac4j.core.util.CommonHelper.*;
+import io.buji.pac4j.context.ShiroSessionStore;
+import io.buji.pac4j.engine.ShiroSecurityLogic;
 
 /**
  * <p>This filter protects an url, based on the {@link #securityLogic}.</p>
@@ -58,8 +64,7 @@ public class SecurityFilter implements Filter {
     private Boolean multiProfile;
 
     public SecurityFilter() {
-        securityLogic = new DefaultSecurityLogic<>();
-        ((DefaultSecurityLogic<Object, J2EContext>) securityLogic).setProfileManagerFactory(ShiroProfileManager::new);
+        securityLogic = new ShiroSecurityLogic<>();
     }
 
     @Override


### PR DESCRIPTION
Hello

This pull request aims to simplify the use of the CallbackLogic and SecurityLogic in Buji.

This solves the need to initialize properly the CallbackLogic / SecurityLogic in the constructor. 
This also helps to define custom parameters for the existing callbacklogic / securitylogic in the shiro.ini.
As lambda are not supported in shiro.ini one would always have to define a custom class making use of the ShiroProfileManager only to able to set a property in the configuration. Those classes avoid that situation.

