### PR TITLE
Compete shiro's login before pac4j's login

### DIFF
--- a/src/main/java/io/buji/pac4j/profile/ShiroProfileManager.java
+++ b/src/main/java/io/buji/pac4j/profile/ShiroProfileManager.java
@@ -38,9 +38,9 @@ public class ShiroProfileManager extends ProfileManager<CommonProfile> {
 
     @Override
     public void save(final boolean saveInSession, final CommonProfile profile, final boolean multiProfile) {
-        super.save(saveInSession, profile, multiProfile);
-
         ShiroHelper.populateSubject(retrieveAll(saveInSession));
+
+        super.save(saveInSession, profile, multiProfile);
     }
 
     @Override


### PR DESCRIPTION
#75  fix a problem: Even though `ShiroHelper.populateSubject()` throws an AuthenticationException, pac4j will till treat it as logged in.